### PR TITLE
fix: add permissions added after initial migration

### DIFF
--- a/migrations/3.js
+++ b/migrations/3.js
@@ -1,0 +1,63 @@
+/* eslint-disable no-await-in-loop */
+import _ from "lodash";
+
+/**
+ * @summary Performs migration up from previous data version
+ * @param {Object} context Migration context
+ * @param {Object} context.db MongoDB `Db` instance
+ * @param {Function} context.progress A function to report progress, takes percent
+ *   number as argument.
+ * @return {undefined}
+ */
+async function up({ db, progress }) {
+  const affectedGroups = [
+    "owner",
+    "shop-manager"
+  ];
+
+  const newShopPermissions = [
+    "reaction:legacy:groups/create",
+    "reaction:legacy:groups/delete",
+    "reaction:legacy:groups/manage:accounts",
+    "reaction:legacy:groups/read",
+    "reaction:legacy:groups/update",
+    "reaction:legacy:inventory/update:settings",
+    "reaction:legacy:navigationTreeItems/update:settings",
+    "reaction:legacy:navigationTrees/read:drafts",
+    "reaction:legacy:shipping-rates/update:settings",
+    "reaction:legacy:sitemaps/update:settings",
+    "reaction:legacy:tags/read:invisible",
+    "reaction:legacy:taxes/update:settings"
+  ];
+
+  // get all groups that need new permissions
+  const groups = await db.collection("Groups").find({ slug: { $in: affectedGroups } }).toArray();
+
+  if (groups && Array.isArray(groups)) {
+    // loop over each group
+    for (let index = 0; index < groups.length; index += 1) {
+      const group = groups[index];
+      const newPermissions = [...group.permissions, ...newShopPermissions];
+      // remove duplicates from list
+      const uniquePermissions = _.uniq(newPermissions);
+
+      // update Groups collection with new permissions
+      await db.collection("Groups").updateOne({
+        _id: group._id
+      }, {
+        $set: {
+          permissions: uniquePermissions
+        }
+      });
+
+      progress(Math.floor((((index + 1) / groups.length) / 2) * 100));
+    }
+  }
+
+  progress(100);
+}
+
+export default {
+  down: "impossible",
+  up
+};

--- a/migrations/3.js
+++ b/migrations/3.js
@@ -12,7 +12,7 @@ import _ from "lodash";
 async function up({ db, progress }) {
   const affectedGroups = [
     "owner",
-    "shop-manager"
+    "shop manager"
   ];
 
   const newShopPermissions = [

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -1,12 +1,14 @@
 import { migrationsNamespace } from "./migrationsNamespace.js";
 import migration2 from "./2.js";
+import migration3 from "./3.js";
 
 export default {
   tracks: [
     {
       namespace: migrationsNamespace,
       migrations: {
-        2: migration2
+        2: migration2,
+        3: migration3
       }
     }
   ]

--- a/src/preStartup.js
+++ b/src/preStartup.js
@@ -1,7 +1,7 @@
 import doesDatabaseVersionMatch from "@reactioncommerce/db-version-check";
 import { migrationsNamespace } from "../migrations/migrationsNamespace.js";
 
-const expectedVersion = 2;
+const expectedVersion = 3;
 
 /**
  * @summary Called before startup


### PR DESCRIPTION
Missing permissions need to be added to `owner` and `shop manager` groups in order for API to function properly.

```
    "reaction:legacy:groups/create",
    "reaction:legacy:groups/delete",
    "reaction:legacy:groups/manage:accounts",
    "reaction:legacy:groups/read",
    "reaction:legacy:groups/update",
    "reaction:legacy:inventory/update:settings",
    "reaction:legacy:navigationTreeItems/update:settings",
    "reaction:legacy:navigationTrees/read:drafts",
    "reaction:legacy:shipping-rates/update:settings",
    "reaction:legacy:sitemaps/update:settings",
    "reaction:legacy:tags/read:invisible",
    "reaction:legacy:taxes/update:settings"
```