### PR TITLE
fix: use slug instead of _id in query

### DIFF
--- a/migrations/3.js
+++ b/migrations/3.js
@@ -28,7 +28,7 @@ async function up({ db, progress }) {
   ];
 
   await db.collection("Groups").updateMany({
-    _id: { $in: affectedGroups }
+    slug: { $in: affectedGroups }
   }, {
     $addToSet: { permissions: { $each: newShopPermissions } }
   });


### PR DESCRIPTION
Fix query to search by slug, not ID