### PR TITLE
feat: rename plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# simple-authorization
+# api-plugin-authorization-simple
 
-[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/plugin-simple-authorization.svg)](https://www.npmjs.com/package/@reactioncommerce/plugin-simple-authorization)
-[![CircleCI](https://circleci.com/gh/reactioncommerce/plugin-simple-authorization.svg?style=svg)](https://circleci.com/gh/reactioncommerce/plugin-simple-authorization)
+[![npm (scoped)](https://img.shields.io/npm/v/@reactioncommerce/api-plugin-authorization-simple.svg)](https://www.npmjs.com/package/@reactioncommerce/api-plugin-authorization-simple)
+[![CircleCI](https://circleci.com/gh/reactioncommerce/api-plugin-authorization-simple.svg?style=svg)](https://circleci.com/gh/reactioncommerce/api-plugin-authorization-simple)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 ## Summary
@@ -61,7 +61,7 @@ Context is used to pass any extra information to the permissions check. We use i
 Import this package into the [registerPlugins.js](https://github.com/reactioncommerce/reaction/blob/8b3d66d758c8fe0e2ba1df1958767587ddb7a046/src/registerPlugins.js) file in the Reaction API, and then await its `registerPlugin` function:
 
 ```js
-import registerSimpleAuthorizationPlugin from "@reactioncommerce/plugin-simple-authorization/index.js";
+import registerSimpleAuthorizationPlugin from "@reactioncommerce/api-plugin-authorization-simple/index.js";
 await registerSimpleAuthorizationPlugin(app);
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@reactioncommerce/plugin-simple-authorization",
+  "name": "@reactioncommerce/api-plugin-authorization-simple",
   "version": "0.0.0-development",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "@reactioncommerce/plugin-simple-authorization",
+  "name": "@reactioncommerce/api-plugin-authorization-simple",
   "description": "Simple Authorization plugin for the Reaction API",
   "version": "0.0.0-development",
   "main": "index.js",
   "type": "module",
-  "homepage": "https://github.com/reactioncommerce/plugin-simple-authorization",
-  "url": "https://github.com/reactioncommerce/plugin-simple-authorization",
+  "homepage": "https://github.com/reactioncommerce/api-plugin-authorization-simple",
+  "url": "https://github.com/reactioncommerce/api-plugin-authorization-simple",
   "email": "engineering@reactioncommerce.com",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reactioncommerce/plugin-simple-authorization.git"
+    "url": "git+https://github.com/reactioncommerce/api-plugin-authorization-simple.git"
   },
   "author": {
     "name": "Reaction Commerce",
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/reactioncommerce/plugin-simple-authorization/issues"
+    "url": "https://github.com/reactioncommerce/api-plugin-authorization-simple/issues"
   },
   "sideEffects": false,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import startup from "./startup.js";
 export default async function register(app) {
   await app.registerPlugin({
     label: "Simple Authorization",
-    name: "simple-authorization",
+    name: "authorization-simple",
     version: pkg.version,
     collections: {
       roles: {


### PR DESCRIPTION
Resolves #10 

Rename this plugin from `plugin-simple-authorization` to `api-plugin-authorization-simple`.

This will create a new npm package with a v1.1.0, and this new package will need to be installed in reaction core.

We also need to deprecate the existing npm package.