### PR TITLE
Add invitations role

### DIFF
--- a/migrations/5.js
+++ b/migrations/5.js
@@ -1,0 +1,33 @@
+const affectedGlobalGroups = [
+  "accounts-manager",
+  "system-manager"
+];
+
+const newGlobalPermissions = [
+  "reaction:legacy:invitations/read"
+];
+
+/**
+ * @summary Performs migration up from previous data version
+ * @param {Object} context Migration context
+ * @param {Object} context.db MongoDB `Db` instance
+ * @param {Function} context.progress A function to report progress, takes percent
+ *   number as argument.
+ * @return {undefined}
+ */
+async function up({ db, progress }) {
+  progress(0);
+
+  await db.collection("Groups").updateMany({
+    slug: { $in: affectedGlobalGroups }
+  }, {
+    $addToSet: { permissions: { $each: newGlobalPermissions } }
+  });
+
+  progress(100);
+}
+
+export default {
+  down: "impossible",
+  up
+};

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -2,6 +2,7 @@ import { migrationsNamespace } from "./migrationsNamespace.js";
 import migration2 from "./2.js";
 import migration3 from "./3.js";
 import migration4 from "./4.js";
+import migration5 from "./5.js";
 
 export default {
   tracks: [
@@ -10,7 +11,8 @@ export default {
       migrations: {
         2: migration2,
         3: migration3,
-        4: migration4
+        4: migration4,
+        5: migration5
       }
     }
   ]

--- a/src/preStartup.js
+++ b/src/preStartup.js
@@ -1,7 +1,7 @@
 import doesDatabaseVersionMatch from "@reactioncommerce/db-version-check";
 import { migrationsNamespace } from "../migrations/migrationsNamespace.js";
 
-const expectedVersion = 4;
+const expectedVersion = 5;
 
 /**
  * @summary Called before startup

--- a/src/util/defaultRoles.js
+++ b/src/util/defaultRoles.js
@@ -103,7 +103,8 @@ export const defaultAccountsManagerRoles = [
   "reaction:legacy:accounts/remove:address-books",
   "reaction:legacy:accounts/update:address-books",
   "reaction:legacy:accounts/update:currency",
-  "reaction:legacy:accounts/update:language"
+  "reaction:legacy:accounts/update:language",
+  "reaction:legacy:invitations/read"
 ];
 
 export const defaultSystemManagerRoles = [


### PR DESCRIPTION
Merge with [api-migrations#10](https://github.com/reactioncommerce/api-migrations/pull/10).

This PR adds the `"reaction:legacy:invitations/read"` role, used by [api-plugin-accounts#16](https://github.com/reactioncommerce/api-plugin-accounts/pull/16).