### PR TITLE
Add offset for Roles pagination

### DIFF
--- a/src/schemas/role.graphql
+++ b/src/schemas/role.graphql
@@ -65,6 +65,9 @@ extend type Shop {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,
 
@@ -90,6 +93,9 @@ extend type Query {
 
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
 
     "Return results sorted in this order"
     sortOrder: SortOrder = asc,


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Resolves https://github.com/reactioncommerce/reaction/issues/6252
Impact: **minor**
Type: **bugfix**

## Issue
Missing offset params for pagination for roles queries
