### PR TITLE
Add invitations/read role in default roles

### DIFF
--- a/src/util/defaultRoles.js
+++ b/src/util/defaultRoles.js
@@ -117,5 +117,6 @@ export const defaultSystemManagerRoles = [
   "reaction:legacy:groups/read",
   "reaction:legacy:groups/update",
   "reaction:legacy:shops/create",
-  "reaction:legacy:shops/read"
+  "reaction:legacy:shops/read",
+  "reaction:legacy:invitations/read"
 ];


### PR DESCRIPTION
Goes along with [`api-plugin-accounts#43`](https://github.com/reactioncommerce/api-plugin-accounts/pull/43). Adds the `reaction:legacy:invitations/read` role to the default roles for `system-manager`.